### PR TITLE
Add babel/core peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@11ty/eleventy": "^1.0.1",
     "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
     "@babel/eslint-parser": "^7.17.0",
+    "@babel/core": "^7.11.0",
     "@custom-elements-manifest/analyzer": "^0.5.7",
     "@open-wc/testing": "^3.1.5",
     "@rollup/plugin-node-resolve": "^13.3.0",


### PR DESCRIPTION
If you just attempt to npm install with babel/eslint-parser, you get a warning:
"npm WARN @babel/eslint-parser@7.18.2 requires a peer of @babel/core@>=7.11.0 but none is installed. You must install peer dependencies yourself."

You also get an error when trying to `npm run lint`. 

So this PR adds it explicitly to package.json. I'm not sure if its best practice to leave peer dependencies out of package.json, but I personally didn't notice the warning so I did a bunch of poking around to understand why the dependency was missing.
