### PR TITLE
Improve bundling/minification recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,15 @@ npm run docs:watch
 
 The site will usually be served at http://localhost:8000.
 
+**Note**: The project uses Rollup to bundle and minify the source code for the docs site and not to publish to NPM. For bundling and minification, check the [Bundling and minification](#bundling-and-minification) section.
+
 ## Bundling and minification
 
-This starter project doesn't include any build-time optimizations like bundling or minification. We recommend publishing components as unoptimized JavaScript modules, and performing build-time optimizations at the application level. This gives build tools the best chance to deduplicate code, remove dead code, and so on.
+As stated in the [static site generation](#static-site) section, the bundling and minification setup in the Rollup configuration in this project is there specifically for the docs generation.
 
-For information on building application projects that include LitElement components, see [Build for production](https://lit.dev/docs/tools/production/) on the LitElement site.
+We recommend publishing components as unoptimized JavaScript modules and performing build-time optimizations at the application level. This gives build tools the best chance to deduplicate code, remove dead code, and so on.
+
+Please check the [Publishing best practices](https://lit.dev/docs/tools/publishing/#publishing-best-practices) for information on publishing reusable Web Components, and [Build for production](https://lit.dev/docs/tools/production/) for building application projects that include LitElement components, on the Lit site.
 
 ## More information
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,10 @@ export default {
   plugins: [
     replace({'Reflect.decorate': 'undefined'}),
     resolve(),
+    /**
+     * This minification setup serves the static site generation.
+     * For bundling and minification, check the README.md file.
+     */
     terser({
       ecma: 2017,
       module: true,


### PR DESCRIPTION
Solves [lit.dev's #1161](https://github.com/lit/lit.dev/issues/1161)

* Inform developers that the `terser` configuration is targeting the docs static site generation
* Refer to the Lit site for best practices on publishing Web Components and applications that include them.