### PR TITLE
Update rollup.config.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@
  */
 
 import summary from 'rollup-plugin-summary';
-import {terser} from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 


### PR DESCRIPTION
After running npm audit fix (or before I don't know if the audit created the issue), the terser import created the error: 

`[!] TypeError: Invalid module "@rollup-plugin-terser" is not a valid package name imported from C:\Users\yanameboi\source\lit-element-starter-js\rollup.config.js`  

when `npm run docs ` was run. 